### PR TITLE
Fixes for the Registry CI

### DIFF
--- a/.github/workflows/cluster-rotate.yml
+++ b/.github/workflows/cluster-rotate.yml
@@ -61,8 +61,8 @@ jobs:
             cluster_prefix="${git_repository_owner}"
           fi
           echo "::set-output name=cluster_id::${cluster_id}"
-          echo "::set-env name=CLUSTER_NAME::${cluster_prefix}${cluster_id}"
-          echo "::set-env name=ARTIFACT_DIR::catapult/build${cluster_prefix}${cluster_id}"
+          echo "CLUSTER_NAME=${cluster_prefix}${cluster_id}" >> $GITHUB_ENV
+          echo "ARTIFACT_DIR=catapult/build${cluster_prefix}${cluster_id}" >> $GITHUB_ENV
 
       - name: Drop OPENRC
         env:
@@ -126,7 +126,7 @@ jobs:
           cd catapult
           echo "::set-output name=step_reached::true"
           OWNER=${CLUSTER_NAME} BACKEND=caasp4os make k8s
-          echo "::set-env name=KUBECONFIG::$(realpath build${{ env.CLUSTER_NAME }}/kubeconfig)"
+          echo "KUBECONFIG=$(realpath build${{ env.CLUSTER_NAME }}/kubeconfig)" >> $GITHUB_ENV
 
       - name: Archive deployment artifacts
         if: always() && steps.deploy_cluster.outputs.step_reached

--- a/.github/workflows/obs-trigger.yml
+++ b/.github/workflows/obs-trigger.yml
@@ -35,7 +35,7 @@ jobs:
         run: |
           mkdir -p ${osc_config_dir}
           echo "${sec_osc_config}" | base64 -d > ${osc_config_dir}/oscrc
-          echo "::set-env name=OSC_CONFIG::${osc_config_dir}/oscrc"
+          echo "OSC_CONFIG=${osc_config_dir}/oscrc" >> $GITHUB_ENV
 
       - name: "Watching projects..."
         run: |

--- a/.github/workflows/registry-2.0.yml
+++ b/.github/workflows/registry-2.0.yml
@@ -14,11 +14,11 @@ on:
 env:
   REGISTRY_VERSION: "2.0"
   CHART_VERSION: "1.4"
+  RC_CHANNEL: "#ecosystem-ci"
   HELM_EXPERIMENTAL_OCI: 1
   HELM_CACHE_HOME: ".cache"
   HELM_CONFIG_HOME: ".config"
   HELM_DATA_HOME: ".local/share"
-  RC_CHANNEL: "#ecosystem-ci"
 
 jobs:
   test_suse_private_registry:
@@ -95,8 +95,8 @@ jobs:
           GH_API_HEADER="authorization: Bearer ${{ secrets.GITHUB_TOKEN }}"
           git_repository="${GITHUB_REPOSITORY#*/}"
           git_repository_owner="${GITHUB_REPOSITORY%/*}"
-          cluster_prefix="${git_repository}-ci"
-          if [[ "${git_repository_owner}" != "suse" ]]; then
+          cluster_prefix="ecosystem"
+          if [[ "${git_repository_owner}" != "SUSE" ]]; then
             cluster_prefix="${git_repository_owner}"
           fi
           active_cluster_artifacts_url=$(curl -sH "${GH_API_HEADER}" \

--- a/.github/workflows/registry-2.1.yml
+++ b/.github/workflows/registry-2.1.yml
@@ -128,6 +128,7 @@ jobs:
             ingress:
               hosts:
                 core: "${NAMESPACE}.${INGRESS_IP}.nip.io"
+                notary: "notary.${NAMESPACE}.${INGRESS_IP}.nip.io"
           externalURL: "https://${NAMESPACE}.${INGRESS_IP}.nip.io"
           core:
             # Set the GC time window to 0 for the GC tests to pass

--- a/.github/workflows/registry-2.1.yml
+++ b/.github/workflows/registry-2.1.yml
@@ -14,11 +14,11 @@ on:
 env:
   REGISTRY_VERSION: "2.1"
   CHART_VERSION: "1.5"
+  RC_CHANNEL: "#ecosystem-ci"
   HELM_EXPERIMENTAL_OCI: 1
   HELM_CACHE_HOME: ".cache"
   HELM_CONFIG_HOME: ".config"
   HELM_DATA_HOME: ".local/share"
-  RC_CHANNEL: "#ecosystem-ci"
 
 jobs:
   test_suse_private_registry:
@@ -95,8 +95,8 @@ jobs:
           GH_API_HEADER="authorization: Bearer ${{ secrets.GITHUB_TOKEN }}"
           git_repository="${GITHUB_REPOSITORY#*/}"
           git_repository_owner="${GITHUB_REPOSITORY%/*}"
-          cluster_prefix="${git_repository}-ci"
-          if [[ "${git_repository_owner}" != "suse" ]]; then
+          cluster_prefix="ecosystem"
+          if [[ "${git_repository_owner}" != "SUSE" ]]; then
             cluster_prefix="${git_repository_owner}"
           fi
           active_cluster_artifacts_url=$(curl -sH "${GH_API_HEADER}" \


### PR DESCRIPTION
A couple more fixes for the registry CI:

* Replace set-env with environment files for the obs trigger and rotate kubernetes cluster workflow (see [1]).
* Fix the cluster prefix when fetching the kubeconfig as it was referencing the previous repository name
* Add notary hostname in the helm values for registry 2.1

1. https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/