### PR TITLE
Use explicit default admin password for 2.1

### DIFF
--- a/.github/workflows/registry-2.1.yml
+++ b/.github/workflows/registry-2.1.yml
@@ -130,6 +130,7 @@ jobs:
                 core: "${NAMESPACE}.${INGRESS_IP}.nip.io"
                 notary: "notary.${NAMESPACE}.${INGRESS_IP}.nip.io"
           externalURL: "https://${NAMESPACE}.${INGRESS_IP}.nip.io"
+          harborAdminPassword: "Harbor12345"
           core:
             # Set the GC time window to 0 for the GC tests to pass
             gcTimeWindowHours: 0


### PR DESCRIPTION
The SUSE Private Registry helm chart for 2.1 now defaults to
generating a password for the Harbor admin account. We need the
previous password value to remain the same, otherwise the integration
tests will fail (yes, sadly the default password value is hard-coded
in the integration test code).