### PR TITLE
Increase helm test timeout

### DIFF
--- a/.github/workflows/registry-2.0.yml
+++ b/.github/workflows/registry-2.0.yml
@@ -167,7 +167,7 @@ jobs:
           release_name=${NAMESPACE}
           namespace=${NAMESPACE}
           mkdir test_report
-          helm test -n $namespace $release_name --timeout 30m &
+          helm test -n $namespace $release_name --timeout 45m &
           helm_test_pid=$!
           test_pods=$(helm status -n $namespace $release_name -o json | jq -r .hooks[].name)
           until kubectl exec -n $namespace $test_pods "--" pgrep "pybot|robot" &> /dev/null; do

--- a/.github/workflows/registry-2.1.yml
+++ b/.github/workflows/registry-2.1.yml
@@ -170,7 +170,7 @@ jobs:
           release_name=${NAMESPACE}
           namespace=${NAMESPACE}
           mkdir test_report
-          helm test -n $namespace $release_name --timeout 30m &
+          helm test -n $namespace $release_name --timeout 45m &
           helm_test_pid=$!
           test_pods=$(helm status -n $namespace $release_name -o json | jq -r .hooks[].name)
           until kubectl exec -n $namespace $test_pods "--" pgrep "pybot|robot" &> /dev/null; do


### PR DESCRIPTION
Sometimes it can take longer than 30 minutes for the integration
testing to complete, especially since two jobs are running at the
same time.