### PR TITLE
Fix ingress IP on SPR 2.0 and namespace deletion

### DIFF
--- a/.github/workflows/cluster-rotate.yml
+++ b/.github/workflows/cluster-rotate.yml
@@ -98,9 +98,12 @@ jobs:
         run: |
           if [ -f "${ARTIFACT_DIR}/kubeconfig" ]; then
             export KUBECONFIG="${ARTIFACT_DIR}/kubeconfig"
-            for n in $(kubectl get ns -o=custom-columns=kube-:.metadata.name | grep -v "kube-\|default"); do
-              kubectl delete ns $n
-            done
+            kubectl get ns --no-headers -o=custom-columns=:.metadata.name | grep -v \
+              "kube-\|default\|$(echo ${CLUSTER_SERVICES} | sed -r 's/ /\\|/g')" \
+              | xargs --no-run-if-empty kubectl delete ns
+            if [[ "${CLUSTER_SERVICES}" != "" ]]; then
+              kubectl delete ns ${CLUSTER_SERVICES} || true
+            fi
           fi
 
       - name: Delete virtual resources on ECP

--- a/.github/workflows/cluster-rotate.yml
+++ b/.github/workflows/cluster-rotate.yml
@@ -180,8 +180,10 @@ jobs:
             esac
           done
 
-      - name: Save new CLUSTER_ID
-        run: echo "${{ steps.set_cluster_id.outputs.cluster_id }}" > CLUSTER_ID
+      - name: Save new CLUSTER_ID and set node kubeconfig
+        run: |
+          echo "${{ steps.set_cluster_id.outputs.cluster_id }}" > CLUSTER_ID
+          cp ${KUBECONFIG} ~/.kube/config
 
       - name: Archive cluster ID
         if: always()

--- a/.github/workflows/registry-2.0.yml
+++ b/.github/workflows/registry-2.0.yml
@@ -120,8 +120,7 @@ jobs:
 
       - name: Generate helm values
         run: |
-          INGRESS_IP=$(kubectl get svc nginx-ingress-controller -n nginx-ingress \
-          -o json | jq -r ".status.loadBalancer.ingress[].ip")
+          INGRESS_IP="$(kubectl get svc --all-namespaces -l app=nginx-ingress | awk '/LoadBalancer/ { print $5 }')"
           echo "INGRESS_IP=${INGRESS_IP}" >> $GITHUB_ENV
           cat << EOF | tee ${NAMESPACE}.yaml
           suse:


### PR DESCRIPTION
The services namespaces should be deleted after other namespaces or it can leave namespaces stuck on deletion.

This change also fixes the SPR 2.0 workflow by using a label to get the ingress IP instead.