### PR TITLE
Set regitry replicas to 1 on HA+redis-operator

### DIFF
--- a/tests/registry/ha+redis-operator/values.yaml
+++ b/tests/registry/ha+redis-operator/values.yaml
@@ -40,7 +40,7 @@ core:
 jobservice:
   replicas: 2
 registry:
-  replicas: 2
+  replicas: 1
 trivy:
   replicas: 2
   gitHubToken: "${github_token}"


### PR DESCRIPTION
Using a scaled registry with a shared NFS volume is known to not be
stable (see [1]).

1. https://docs.openshift.com/container-platform/3.10/install_config/registry/registry_known_issues.html#known-issue-nfs-image-push-fails