### PR TITLE
EKS: Wait for DB instance before creating databases

### DIFF
--- a/tests/registry/ha+tls+external-db_redis/infra.tfvars
+++ b/tests/registry/ha+tls+external-db_redis/infra.tfvars
@@ -1,4 +1,4 @@
-k8s_enabled = true
-db_enabled = true
+k8s_enabled            = true
+db_enabled             = true
 object_storage_enabled = true
-redis_enabled = true
+redis_enabled          = true


### PR DESCRIPTION
Need to wait until the `aws_rds_cluster_instance` resource is created and the url is resolvable before creating the registry databases.